### PR TITLE
Added options to check interface by ifDescr regex, and also by ifAlias regex

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,18 +3,13 @@
 Release History
 ---------------
 
-1.3.7 (2017-06-11)
-++++++++++++++++++
-
-* fix nelsnmp version to 0.2.5 due to bug https://github.com/networklore/nelsnmp/issues/8 (pablodav)
-
-1.3.6 (2017-05-09)
+1.3.6 (2017-07-18)
 ++++++++++++++++++
 
 * Added options to check interface by ifDescr regex (pablodav)
 * Added options to check interface by ifAlias (pablodav)
 * Added option to ignore some interface by ifDescr (pablodav)
-* Add setuptools>=35.0.2 to dependencies to avoid installation issues on outdated environments (pablodav)
+* fix nelsnmp version to 0.2.5 due to bug https://github.com/networklore/nelsnmp/issues/8 (pablodav)
 
 1.3.5 (2016-11-04)
 ++++++++++++++++++

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,13 @@
 Release History
 ---------------
 
+1.4.0 (2017-05-09)
+++++++++++++++++++
+
+* Added options to check interface by ifDescr regex (pablodav)
+* Added options to check interface by ifAlias (pablodav)
+* Added option to ignore some interface by ifDescr (pablodav)
+
 1.3.5 (2016-11-04)
 ++++++++++++++++++
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,7 +3,7 @@
 Release History
 ---------------
 
-1.4.0 (2017-05-09)
+1.3.6 (2017-05-09)
 ++++++++++++++++++
 
 * Added options to check interface by ifDescr regex (pablodav)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,12 +3,18 @@
 Release History
 ---------------
 
+1.3.7 (2017-06-11)
+++++++++++++++++++
+
+* fix nelsnmp version to 0.2.5 due to bug https://github.com/networklore/nelsnmp/issues/8 (pablodav)
+
 1.3.6 (2017-05-09)
 ++++++++++++++++++
 
 * Added options to check interface by ifDescr regex (pablodav)
 * Added options to check interface by ifAlias (pablodav)
 * Added option to ignore some interface by ifDescr (pablodav)
+* Add setuptools>=35.0.2 to dependencies to avoid installation issues on outdated environments (pablodav)
 
 1.3.5 (2016-11-04)
 ++++++++++++++++++

--- a/lib/nelmon/__init__.py
+++ b/lib/nelmon/__init__.py
@@ -1,3 +1,3 @@
 """Nelmon - Networklore Monitoring Toolkit."""
-__version__ = "1.3.5"
+__version__ = "1.4.0"
 __author__ = 'Patrick Ogenstad'

--- a/lib/nelmon/__init__.py
+++ b/lib/nelmon/__init__.py
@@ -1,3 +1,3 @@
 """Nelmon - Networklore Monitoring Toolkit."""
-__version__ = "1.3.7"
+__version__ = "1.3.6"
 __author__ = 'Patrick Ogenstad'

--- a/lib/nelmon/__init__.py
+++ b/lib/nelmon/__init__.py
@@ -1,3 +1,3 @@
 """Nelmon - Networklore Monitoring Toolkit."""
-__version__ = "1.3.6"
+__version__ = "1.3.7"
 __author__ = 'Patrick Ogenstad'

--- a/lib/nelmon/__init__.py
+++ b/lib/nelmon/__init__.py
@@ -1,3 +1,3 @@
 """Nelmon - Networklore Monitoring Toolkit."""
-__version__ = "1.4.0"
+__version__ = "1.3.6"
 __author__ = 'Patrick Ogenstad'

--- a/lib/nelmon/cli/check_admin_up_oper_down.py
+++ b/lib/nelmon/cli/check_admin_up_oper_down.py
@@ -33,7 +33,7 @@ def main():
                                   help='Search over Interface alias with regex'
                                        'example: UPLINK'
                                        'matches any interfaces with keyword UPLINK on its alias')
-    argparser.parser.add_argument('-ia', '--ignore_alias', dest='ifdescr_ignore_arg',  default=None, const=None,
+    argparser.parser.add_argument('-id', '--ignore_descr', dest='ifdescr_ignore_arg',  default=None, const=None,
                                   help='Search over Interface ifDescr with regex and ignores that'
                                        'example: Stack')
 
@@ -115,7 +115,7 @@ def main():
     # Change the down_interfaces only to those that ifDescr doesn't match regex passed to ifdescr_ignore_arg
     if ifdescr_ignore_arg:
         for ifIndex, ifDescr in interface_descr.items():
-            # Add the regex from --ia command, like: GigabitEthernet(\d+)/0/(4[78]|[5][0-2]) or Stack
+            # Add the regex from --id command, like: GigabitEthernet(\d+)/0/(4[78]|[5][0-2]) or Stack
             ifdescr_regex = re.compile(ifdescr_ignore_arg)
             # Remove from down_interfaces if regex matches
             if ifdescr_regex.search(ifDescr):

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ config = {
     'author_email': 'patrick@ogenstad.com',
     'license': 'Apache',
     'url': 'https://networklore.com/nelmon/',
-    'install_requires': ['argparse', 'nelsnmp >= 0.2.3', 'PyYAML', 'requests', 'setuptools>=35.0.2'],
+    'install_requires': ['argparse', 'nelsnmp==0.2.5', 'PyYAML', 'requests', 'setuptools>=35.0.2'],
     'classifiers': ['Development Status :: 4 - Beta',
                     'Intended Audience :: Developers',
                     'Intended Audience :: System Administrators']

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ config = {
     'author_email': 'patrick@ogenstad.com',
     'license': 'Apache',
     'url': 'https://networklore.com/nelmon/',
-    'install_requires': ['argparse', 'nelsnmp==0.2.5', 'PyYAML', 'requests', 'setuptools>=35.0.2'],
+    'install_requires': ['argparse', 'nelsnmp==0.2.5', 'PyYAML', 'requests'],
     'classifiers': ['Development Status :: 4 - Beta',
                     'Intended Audience :: Developers',
                     'Intended Audience :: System Administrators']

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ config = {
     'author_email': 'patrick@ogenstad.com',
     'license': 'Apache',
     'url': 'https://networklore.com/nelmon/',
-    'install_requires': ['argparse', 'nelsnmp >= 0.2.3', 'PyYAML', 'requests'],
+    'install_requires': ['argparse', 'nelsnmp >= 0.2.3', 'PyYAML', 'requests', 'setuptools>=35.0.2'],
     'classifiers': ['Development Status :: 4 - Beta',
                     'Intended Audience :: Developers',
                     'Intended Audience :: System Administrators']


### PR DESCRIPTION
Tested in real case, example: 

```shell
user@host:~$ nm_check_admin_up_oper_down  -P 2c -C public -H HOSTNAME -c
5 interfaces down
StackPort1
GigabitEthernet1/0/46 - *** some int description ***
GigabitEthernet1/0/47 - UPLINK to SWITCHX
StackSub-St1-1
StackSub-St1-2

user@host:~$ nm_check_admin_up_oper_down  -P 2c -C public -H HOSTNAME -c -d 'GigabitEthernet(\d+)/0/(4[78]|[5][0-2])'
1 interfaces down
GigabitEthernet1/0/47 - UPLINK to SWITCHX

user@host:~$ nm_check_admin_up_oper_down  -P 2c -C public -H HOSTNAME -c -al 'UPLINK'
1 interfaces down
GigabitEthernet1/0/47 - UPLINK to SWITCHX
```
